### PR TITLE
Update to 1.21.6 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.20.6
 yarn_mappings=1.20.6+build.1
 loader_version=0.15.10
 # Mod Properties
-mod_version=2.2.0
+mod_version=2.2.1
 maven_group=gg.rme
 archives_base_name=rmes-durability-tooltips
 # Dependencies

--- a/src/client/java/gg/rme/durabilitytooltips/config/ModMenuIntegration.java
+++ b/src/client/java/gg/rme/durabilitytooltips/config/ModMenuIntegration.java
@@ -3,19 +3,24 @@ package gg.rme.durabilitytooltips.config;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.MinecraftVersion;
 import net.minecraft.text.Text;
+
+import java.util.Objects;
 
 public class ModMenuIntegration implements ModMenuApi {
 
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        if (FabricLoader.getInstance().isModLoaded("yet_another_config_lib_v3")) {
-            return new YACLConfigScreen().create();
-        } else if (FabricLoader.getInstance().isModLoaded("cloth-config")) {
-            return new ClothConfigScreen().create();
+            if (FabricLoader.getInstance().isModLoaded("yet_another_config_lib_v3")) {
+                return new YACLConfigScreen().create();
+            } else if (FabricLoader.getInstance().isModLoaded("cloth-config")) {
+                return new ClothConfigScreen().create();
+            }
+        if (!Objects.equals(MinecraftVersion.CURRENT.getName(), "1.21.6")) {
+            return parent -> new InformationScreen(parent, Text.translatable("title.rmes-durability-tooltips.config"));
         }
-
-        return parent -> new InformationScreen(parent, Text.translatable("title.rmes-durability-tooltips.config"));
+        return null;
     }
 
 }

--- a/src/client/resources/fabric.mod.json
+++ b/src/client/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "rmes-durability-tooltips",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "name": "RME's Durability Tooltips",
   "description": "Simple and customisable durability tooltips.",
   "authors": [
@@ -29,7 +29,7 @@
   "depends": {
     "fabricloader": ">=0.15",
     "fabric": "*",
-    "minecraft": ">=1.20.6 <=1.21.5"
+    "minecraft": ">=1.20.6 <=1.21.6"
   },
   "suggests": {
     "modmenu": ">=7.2.1",


### PR DESCRIPTION
[Fixed crash when no visual config deps installed on 1.21.6](https://github.com/RMEngelbrecht/DurabilityTooltips/commit/464ddb5763e305c445eff0c9f749104ab9628dc4)
[Update to 1.21.6 & bump version number](https://github.com/RMEngelbrecht/DurabilityTooltips/commit/2e9d8dfc541a16a7d0a0e0e002719ceca7954de5)